### PR TITLE
Set live-build mode to progress-linux

### DIFF
--- a/webconverger/auto/config
+++ b/webconverger/auto/config
@@ -9,7 +9,7 @@ lb config noauto --clean \
 	-k "486 686-pae" \
 	-a i386 \
 	--parent-archive-areas "main contrib non-free" \
-	--mode progress --distribution artax \
+	--mode progress-linux --distribution artax \
 	--debian-installer false \
 	--debian-installer-gui false \
 	--syslinux-theme live-build \


### PR DESCRIPTION
The "progress" mode was renamed to "progress-linux" in live-build
3.0~a67.

Since we use an existing chroot, with preinstalled packages and a
configured sources.list, this didn't actually break regular builds.
However, it did break building hdd images, since the default disk label
is based on the mode, but lb_binary_hdd can't handle an empty disk
label.
