### PR TITLE
Fix HDD images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 webconverger/.build
-webconverger/binary.hybrid.iso
-webconverger/binary.img
+webconverger/live-image-i386
+webconverger/live-image-i386.hybrid.iso
 webconverger/binary.vdi
 webconverger/binary/
 webconverger/chroot/

--- a/webconverger/Makefile
+++ b/webconverger/Makefile
@@ -21,7 +21,7 @@ build-vbox-hdd: build-hdd
 		UUID="--uuid $$(VBoxManage showhdinfo binary.vdi | awk '$$1 == "UUID:" {print $$2}')"; \
 		rm -f binary.vdi; \
 	fi; \
-	VBoxManage convertfromraw binary.img binary.vdi $$UUID
+	VBoxManage convertfromraw live-image-i386 binary.vdi $$UUID
 
 binary: clean
 	# Check that the chroot has no changes

--- a/webconverger/Makefile
+++ b/webconverger/Makefile
@@ -1,6 +1,17 @@
 REPO := https://github.com/Webconverger/webc.git
 BRANCH := master
 
+# Check if live-build is new enough
+LB_VERSION:=$(shell lb --version)
+MIN_LB_VERSION:=4.0.0
+TOONEW_LB_VERSION:=5.0~
+ifneq ($(shell dpkg --compare-versions "$(LB_VERSION)" ge "$(MIN_LB_VERSION)"; echo $$?),0)
+$(error live-build is too old, needs at least version $(MIN_LB_VERSION) $(CMP))
+endif
+ifneq ($(shell dpkg --compare-versions "$(LB_VERSION)" lt "$(TOONEW_LB_VERSION)"; echo $$?),0)
+$(error live-build is too new, needs at less than version $(TOONEW_LB_VERSION) $(CMP))
+endif
+
 VERSION=$(shell cd chroot; git describe --always)
 
 build: TYPE=iso-hybrid

--- a/webconverger/Makefile
+++ b/webconverger/Makefile
@@ -18,10 +18,10 @@ build-vbox-hdd: build-hdd
 	# If there's already a vdi file, try to keep the UUID the same,
 	# so you don't have to re-add the vdi file in Virtualbox.
 	if [ -f "$(VDI)" ]; then \
-		UUID="--uuid $$(VBoxManage showhdinfo binary.vdi | awk '$$1 == "UUID:" {print $$2}')"; \
-		rm -f binary.vdi; \
+		UUID="--uuid $$(VBoxManage showhdinfo $(VDI) | awk '$$1 == "UUID:" {print $$2}')"; \
+		rm -f $(VDI); \
 	fi; \
-	VBoxManage convertfromraw live-image-i386 binary.vdi $$UUID
+	VBoxManage convertfromraw live-image-i386 $(VDI) $$UUID
 
 binary: clean
 	# Check that the chroot has no changes

--- a/webconverger/config/bootloaders/syslinux/syslinux/libcom32.c32
+++ b/webconverger/config/bootloaders/syslinux/syslinux/libcom32.c32
@@ -1,0 +1,1 @@
+/usr/lib/syslinux/modules/bios/libcom32.c32

--- a/webconverger/config/bootloaders/syslinux/syslinux/libutil.c32
+++ b/webconverger/config/bootloaders/syslinux/syslinux/libutil.c32
@@ -1,0 +1,1 @@
+/usr/lib/syslinux/modules/bios/libutil.c32

--- a/webconverger/config/bootloaders/syslinux/syslinux/vesamenu.c32
+++ b/webconverger/config/bootloaders/syslinux/syslinux/vesamenu.c32
@@ -1,1 +1,1 @@
-/usr/lib/syslinux/vesamenu.c32
+/usr/lib/syslinux/modules/bios/vesamenu.c32


### PR DESCRIPTION
This fixes some problems with HDD images and live-build 4.x.

Note that the current version of live-build (4.0.3 in Jessie, as well as the latest 4.0.5 upstream) have some problems with HDD images as well. This PR fixes HDD images, if the  following patch to live-build is also applied:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=773833#25