### PR TITLE
Use deb.debian.org to pull in sources.

### DIFF
--- a/patches/apply
+++ b/patches/apply
@@ -25,7 +25,7 @@ do
 	esac
 
 	# Install build-dependencies
-	echo "deb-src http://httpredir.debian.org/debian ${BACKPORT_FROM} main" \
+	echo "deb-src http://deb.debian.org/debian ${BACKPORT_FROM} main" \
 		> /etc/apt/sources.list.d/webconverger.list
 	apt-get update --yes
 	apt-get build-dep --yes ${SRC}


### PR DESCRIPTION
httpredir is not maintained.  This produces the following intermittent error:
```
+ apt-get build-dep --yes live-build
Reading package lists...
Building dependency tree...
Reading state information...
E: You must put some 'source' URIs in your sources.list
The command '/bin/sh -c /root/Debian-Live-config/patches/apply' returned a non-zero code: 100
```

Refer to https://lists.debian.org/debian-mirrors/2017/02/msg00000.html